### PR TITLE
do not show Load More if records is filtered + remove "Tomt"

### DIFF
--- a/force-app/main/default/lwc/timeline/slick.css
+++ b/force-app/main/default/lwc/timeline/slick.css
@@ -1,6 +1,5 @@
 .custom-container {
     align-items: flex-start;
-    border-bottom: 1px solid #767676;
     margin: 0 1rem;
 }
 
@@ -11,4 +10,8 @@
 
 .right-column {
     padding-top: 1.75rem;
+}
+
+.border-bottom {
+    border-bottom: 1px solid #767676;
 }

--- a/force-app/main/default/lwc/timeline/slick.html
+++ b/force-app/main/default/lwc/timeline/slick.html
@@ -35,36 +35,34 @@
                 {emptySubtitle}
             </div>
         </div>
-        <div lwc:else>
-            <ul class="slds-timeline">
-                <lightning-accordion
-                    allow-multiple-sections-open
-                    active-section-name={openAccordionSections}
-                    onsectiontoggle={handleSectionToggle}
-                    lwc:if={finishedLoading}
-                >
-                    <template for:each={data} for:item="group" for:index="groupIndex">
-                        <c-timeline-group
-                            key={group.id}
-                            group={group}
-                            labels={labels}
-                            amount-of-records={amountOfRecords}
-                            amount-of-records-to-load={amountOfRecordsToLoad}
-                            open-accordion-sections={openAccordionSections}
-                            group-index={groupIndex}
-                            expand-check={expandCheck}
-                            log-event={logEvent}
-                            design={design}
-                            include-amount-in-title={includeAmountInTitle}
-                        >
-                        </c-timeline-group>
-                    </template>
-                </lightning-accordion>
-            </ul>
-            <div lwc:if={hasMoreDataToLoad} class="slds-align_absolute-center loadMoreFooter" onclick={loadMore}>
-                <button class="slds-button loadMoreBtn">{labels.loadMore}</button>
-            </div>
-            <div lwc:else class="slds-align_absolute-center slds-text-color_weak slds-var-p-top_medium"></div>
+        <ul class="slds-timeline">
+            <lightning-accordion
+                allow-multiple-sections-open
+                active-section-name={openAccordionSections}
+                onsectiontoggle={handleSectionToggle}
+                lwc:if={finishedLoading}
+            >
+                <template for:each={data} for:item="group" for:index="groupIndex">
+                    <c-timeline-group
+                        key={group.id}
+                        group={group}
+                        labels={labels}
+                        amount-of-records={amountOfRecords}
+                        amount-of-records-to-load={amountOfRecordsToLoad}
+                        open-accordion-sections={openAccordionSections}
+                        group-index={groupIndex}
+                        expand-check={expandCheck}
+                        log-event={logEvent}
+                        design={design}
+                        include-amount-in-title={includeAmountInTitle}
+                    >
+                    </c-timeline-group>
+                </template>
+            </lightning-accordion>
+        </ul>
+        <div lwc:if={hasMoreDataToLoad} class="slds-align_absolute-center loadMoreFooter" onclick={loadMore}>
+            <button class="slds-button loadMoreBtn">{labels.loadMore}</button>
         </div>
+        <div lwc:else class="slds-align_absolute-center slds-text-color_weak slds-var-p-top_medium"></div>
     </div>
 </template>

--- a/force-app/main/default/lwc/timeline/slick.html
+++ b/force-app/main/default/lwc/timeline/slick.html
@@ -1,6 +1,6 @@
 <template>
     <div class="slds-theme_default slds-is-relative">
-        <div class="slds-grid custom-container">
+        <div class={headerClass}>
             <div class="slds-col slds-large-size_8-of-12 left-column">
                 <h3 class="slds-card__header-title">
                     <lightning-icon icon-name={headerIcon} size="small" class="slds-var-m-right_small"></lightning-icon>

--- a/force-app/main/default/lwc/timeline/slick.html
+++ b/force-app/main/default/lwc/timeline/slick.html
@@ -31,7 +31,6 @@
             </div>
         </div>
         <div lwc:elseif={empty}>
-            <div class="slds-text-heading_large slds-align_absolute-center">{labels.emptyTitle}</div>
             <div class="slds-text-heading_small slds-align_absolute-center slds-var-m-around_x-large">
                 {emptySubtitle}
             </div>

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -254,7 +254,6 @@ export default class Timeline extends LightningElement {
     }
 
     loadMore() {
-        this.loading = true;
         this.amountOfMonths += this.amountOfMonthsToLoad;
         this.publishAmplitudeEvent('Load more (months)');
     }

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -338,4 +338,8 @@ export default class Timeline extends LightningElement {
     get emptySubtitle() {
         return this.customEmptySubtitle || this.labels.emptySubtitle;
     }
+
+    get headerClass() {
+        return `slds-grid custom-container${this.empty ? '' : ' border-bottom'}`;
+    }
 }

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -150,9 +150,9 @@ export default class Timeline extends LightningElement {
     processTimelineData(data) {
         this.setParams(data);
         this.setData(data);
-        this.setFilterProperties(data);
-        this.setupAccordions(data);
-        this.countRecordsLoaded(data);
+        this.setFilterProperties(this.data);
+        this.setupAccordions(this.data);
+        this.countRecordsLoaded(this.data);
         this.fetchTotalRecords();
     }
 

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -62,6 +62,7 @@ export default class Timeline extends LightningElement {
     collapseText = labels.collapse;
     isRendered = false;
     masterData;
+    isFiltered = false;
 
     render() {
         return this.design === 'Slick' ? slickTemplate : defaultTemplate;
@@ -128,8 +129,8 @@ export default class Timeline extends LightningElement {
             LANG === 'no' && this.headerTitleNorwegian
                 ? this.headerTitleNorwegian
                 : LANG === 'en-US' && this.headerTitleEnglish
-                ? this.headerTitleEnglish
-                : this.labels.activities;
+                  ? this.headerTitleEnglish
+                  : this.labels.activities;
     }
 
     loadMomentJs() {
@@ -296,8 +297,10 @@ export default class Timeline extends LightningElement {
     handleFilter(e) {
         this.refreshData()
             .then(() => {
-                const filteredData = this.template.querySelector('c-timeline-filter').filterRecords(this.masterData);
+                const filterTemplate = this.template.querySelector('c-timeline-filter');
+                const filteredData = filterTemplate.filterRecords(this.masterData);
                 this.data = filteredData;
+                this.isFiltered = !filterTemplate.filterContainsAll();
 
                 this.resetAccordions(this.data);
             })
@@ -321,7 +324,7 @@ export default class Timeline extends LightningElement {
     }
 
     get hasMoreDataToLoad() {
-        return this.recordsLoaded < this.maxRecords;
+        return this.recordsLoaded < this.maxRecords && !this.isFiltered;
     }
 
     get showCreateRecords() {

--- a/force-app/main/default/lwc/timelineFilter/timelineFilter.js
+++ b/force-app/main/default/lwc/timelineFilter/timelineFilter.js
@@ -78,6 +78,7 @@ export default class TimelineFilter extends LightningElement {
         return records.map(this.filterGroupModels.bind(this)).filter((group) => group !== null);
     }
 
+    @api
     filterContainsAll() {
         return Object.values(this.filter).includes('Alle');
     }


### PR DESCRIPTION
Lager pr mot designProperty branchen siden den har siste endringer

Fikser disse problemene: 
- Last flere tilbakestiller visningen, og scroller opp
- Last flere vises etter filter og hvis man trykker på den så laster records som ikke er filtrert
- Fjerne strek under Henvendelser når henvendelselisten er tom og endre til kun "Denne brukeren har ingen registrerte henvendelser" - (fjerne "Tomt!".